### PR TITLE
return original resolver.promise

### DIFF
--- a/lib/tokenbucket.js
+++ b/lib/tokenbucket.js
@@ -503,7 +503,7 @@ TokenBucket = (function() {
         };
       })(this);
       if (this.parentBucket && (this.parentBucket.redis != null)) {
-        return this.parentBucket.loadSaved().then(get);
+        this.parentBucket.loadSaved().then(get);
       } else {
         get();
       }

--- a/lib/tokenbucket.js
+++ b/lib/tokenbucket.js
@@ -456,7 +456,7 @@ TokenBucket = (function() {
         };
       })(this);
       if (this.parentBucket && (this.parentBucket.redis != null)) {
-        return this.parentBucket.save().then(set);
+        this.parentBucket.save().then(set);
       } else {
         set();
       }


### PR DESCRIPTION
otherwise only parentBucket is updated and the promise is resolved too soon. 